### PR TITLE
Added support for Multical 402 additional Water meters

### DIFF
--- a/custom_components/kamstrup_403/sensor.py
+++ b/custom_components/kamstrup_403/sensor.py
@@ -74,6 +74,20 @@ DESCRIPTIONS: list[SensorEntityDescription] = [
         state_class=SensorStateClass.TOTAL_INCREASING,
     ),
     SensorEntityDescription(
+        key="84",  # 0x0054
+        name="WaterMeter1",
+        icon="mdi:water",
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        entity_registry_enabled_default=False,
+    ),
+    SensorEntityDescription(
+        key="85",  # 0x0055
+        name="WaterMeter2",
+        icon="mdi:water",
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        entity_registry_enabled_default=False,
+    ),
+    SensorEntityDescription(
         key="141",  # 0x008D
         name="MinFlow_M",
         icon="mdi:water",


### PR DESCRIPTION
Support for additional water metters connected to Input A&B (VA, VB) on Multical 402
According to [Multical 402 manual](https://www.manualslib.com/manual/1410340/Kamstrup-Multical-402.html?page=55#manual)

![image](https://user-images.githubusercontent.com/64019471/219811897-ea297fd2-dc3d-4ab1-af5e-b713ce69bd7f.png)

[and protocol reference for Multical 801](https://www.askom.pl/WebHelp/Asix_Evo_10/EN/Communication_Drivers_HTML5/index.htm#t=Kmp.htm)

Up to two additional water meters (eg. for cold water) can be connected to Multical 402 and read over IR interface, those are stored in registries 84 and 85.

In my example, no.1 has cold water meter, no. 2 is disconnected.

![image](https://user-images.githubusercontent.com/64019471/219811853-d0925fe9-4b23-4075-8022-315487f87d5c.png)


Tested with Multical 402
Home Assistant 2023.2.5
Supervisor 2023.01.1
Operating System 9.5
Frontend 20230202.0 - latest